### PR TITLE
[Refactor] 신청 유저들 확인 페이지 (리스트) 추가.

### DIFF
--- a/backend/spring-boot-3/src/main/java/back/springbootdeveloper/seungchan/dto/response/NewUsersResponse.java
+++ b/backend/spring-boot-3/src/main/java/back/springbootdeveloper/seungchan/dto/response/NewUsersResponse.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class NewUsersResponse {
+    private Long id;
     private String email;
     private String name;
     private String applicationDate;

--- a/backend/spring-boot-3/src/main/java/back/springbootdeveloper/seungchan/service/TempUserService.java
+++ b/backend/spring-boot-3/src/main/java/back/springbootdeveloper/seungchan/service/TempUserService.java
@@ -24,10 +24,11 @@ public class TempUserService {
         List<NewUsersResponse> newUsersResponseList = new ArrayList<>();
         List<TempUser> tempUserList = tempUserRepository.findAll();
         for (TempUser tempUser : tempUserList) {
+            Long id = tempUser.getId();
             String email = tempUser.getEmail();
             String name = tempUser.getName();
             String applicationDate = tempUser.getApplicationDate();
-            newUsersResponseList.add(new NewUsersResponse(email, name, applicationDate));
+            newUsersResponseList.add(new NewUsersResponse(id, email, name, applicationDate));
         }
         return newUsersResponseList;
     }


### PR DESCRIPTION
이전에는 임시 신청한 유저의 정보중 email, name, applicationData 만보냈지만 
지금은 id, email, name, applicationData의 정보 id 정보까지 보낸다. 
이전에는 url에 보낼수있는 id의 정보를 순서대로 front의 임의대로 보냈지만
지금은 임시 유저 정보의 데이터베이스에 있는 id을 통해 정보를 얻을 수 있는 id의 정보를 받아 /new-users/{id} 의 url에 접근 가능하다.