### PR TITLE
[Feat] 메인페이지 실장이 유저에게 휴가 부여 수정

### DIFF
--- a/frontend/src/atoms/molecule/member-infromation-modal.tsx
+++ b/frontend/src/atoms/molecule/member-infromation-modal.tsx
@@ -53,7 +53,7 @@ export default function MemberInformationModal({ userId, setIsMemberInfoOpen, is
   const giveVacation = () => {
     axAuth(token)({
       method: 'post',
-      url: 'vacation/count',
+      url: 'vacations/count',
       data: {
         vacationCount: vacationCount,
         userId: userId,


### PR DESCRIPTION
api 명세표가 잘못되서  vacation을 vacations으로 변경